### PR TITLE
포스트의 날짜 형식 변경

### DIFF
--- a/op.xml
+++ b/op.xml
@@ -2468,12 +2468,12 @@
                         <b:if cond='data:view.isSingleItem'>
                           <a class='timestamp-link' expr:href='data:post.url' rel='bookmark' title='permanent link'>
                             <time class='published' expr:datetime='data:post.date.iso8601' expr:title='data:post.date.iso8601'>
-                              <data:post.date/>
+                              <data:post.date.year/>/<data:post.date.month/>/<data:post.date.day/>
                             </time>
                           </a>
                         <b:else/>
                           <time class='published' expr:datetime='data:post.date.iso8601' expr:title='data:post.date.iso8601'>
-                            <data:post.date/>
+                            <data:post.date.year/>/<data:post.date.month/>/<data:post.date.day/>
                           </time>
                         </b:if>
                       </b:if>


### PR DESCRIPTION
안녕하세요? Blogger에서 소소하게 테마 개발하고 있는 BINUBALL입니다.한국인이 만든 Blogger 테마는 정말 적어서 테마 하나하나가 정말 귀하네요.
기여가 가능하길래 간단하게 날짜 형식을 변경해 보고 PR을 넣어 봅니다. 6/07/2020 같은 한국인이 읽기 어려운 표시 대신 2020/6/7 형태로 날짜를 표시합니다.
지금 생각해 보니 이곳도 현지화를 해야 할 것 같네요. 대충 아래와 같이 ko에서는 YYYY/MM/DD로 표시되게, en이나 나머지에서는 MM/DD/YYYY로 표시하게 하면 될 것 같습니다.

<b:comment>International language support</b:comment>
<b:if cond='data:blog.locale == &quot;ko&quot;'>
<data:post.date.year/>/<data:post.date.month/>/<data:post.date.day/>
<b:else/>
<data:post.date.month/>/<data:post.date.day/>/<data:post.date.year/>
</b:if>